### PR TITLE
Fixed addLive cells in non fullscreen and improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,24 +13,26 @@
         transform: translate(-50%,-50%);
     }
     .container {
-        height: 200px;
+        width: max-content;
+        padding:10px;
         position: absolute;
-        border: 3px solid green;
-    }
-
-    .horizontal-center {
-        position: relative;
-        left: 50%;
-        -ms-transform: translateX(-50%);
+        left:50%;
         transform: translateX(-50%);
+        z-index: 100;
+        text-transform: capitalize;
+
+        text-align: center;
+        
+        border: 3px solid green;
+        background-color: white;
     }
 </style>
 
 <body>
-    <h3 align=center> Conway's Game of Life </h3>
-    <div class=container">
-        <div class="horizontal-center">
+    <div class="container">
+        <h3> Conway's Game of Life </h3>
             <button onclick="togglePause()">Pause/play</button>
+            <button onclick="fullscreen()">Fullscreen</button>
             <!----
                 <button onclick="drawCellMouse()"> Draw </button>
                 ----->

--- a/main.js
+++ b/main.js
@@ -5,10 +5,9 @@ var gridCopy = [];
 var paused = true;
 
 // GLOBAL VARIABLES HEIGHT AND WIDTH
-// var HEIGHT = 60;
-// var WIDTH = 80;
-var HEIGHT = window.innerHeight/10;
-var WIDTH = window.innerWidth/10;
+var HEIGHT = 60;
+var WIDTH = 80;
+
 var canvas = document.getElementById('gameCanvas');
 
 function togglePause()
@@ -21,7 +20,21 @@ function togglePause()
        paused = false;
     }
 }
-
+//sets height and width then sets up the grid with new size. resets current grid.
+function fullscreen(){
+    if (WIDTH == 80) {
+        canvas.height = window.innerHeight; 
+        canvas.width = window.innerWidth;
+        HEIGHT = window.innerHeight/10;
+        WIDTH = window.innerWidth/10;
+    } else {
+        canvas.height = 600;
+        canvas.width = 600;
+        HEIGHT = 60;
+        WIDTH = 80;
+    }
+    gridSetup();
+}
 window.addEventListener('keydown', function (e) {
     var key = e.key;
     if (key === ' ')// space key
@@ -30,17 +43,28 @@ window.addEventListener('keydown', function (e) {
     }
     });
 
+//calculates cursorpoint - length to element
+function getCursorInCanvas(point){
+    var rect = point.target.getBoundingClientRect();
+    newLifeX = Math.floor((point.clientX-rect.left)/cellSide);
+    newLifeY = Math.floor((point.clientY-rect.top)/cellSide);
+    return [newLifeY,newLifeX];
+}
+
+    
 canvas.addEventListener("mousemove", cursor => {
     if (cursor.buttons == 1){
-        newLifeX = Math.floor(cursor.clientX/10);
-        newLifeY = Math.floor(cursor.clientY/10);
+        points = getCursorInCanvas(cursor);
+        newLifeY = points[0];
+        newLifeX = points[1];
         grid[newLifeY][newLifeX].isAlive = 1;
     }
 });
 
 canvas.addEventListener("click", cursor => {
-        newLifeX = Math.floor(cursor.clientX/10);
-        newLifeY = Math.floor(cursor.clientY/10);
+        points = getCursorInCanvas(cursor)
+        newLifeY = points[0];
+        newLifeX = points[1];
 
         if (grid[newLifeY][newLifeX].isAlive == 1) {
             grid[newLifeY][newLifeX].isAlive = 0;
@@ -54,9 +78,6 @@ window.onload = function () {
     canvasContext = canvas.getContext('2d');
 
     //sets canvas width
-    
-    canvas.height = window.innerHeight; 
-    canvas.width = window.innerWidth;
     
     gridSetup();
 


### PR DESCRIPTION
### changes and additions
* Made the html info be above the canvas, centered.
* added fullscreen button and function.
* fixed the make alive cells by [calculating distance](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) to element and subtracting it, so it now works all the time not just fullscreen!
* Also created a function for the code mentioned above, a bit more DRY :)

Thanks for letting me contribute to your project!

